### PR TITLE
add whatmydevice.com

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -1,6 +1,6 @@
 [
     {
         "domain": "whatmydevice.com",
-        "source": "[SOURCE]"
+        "source": "https://github.com/progzone122/tech-dumbfucks-sites-list/pull/2"
     }
 ]

--- a/domains.json
+++ b/domains.json
@@ -1,1 +1,6 @@
-[]
+[
+    {
+        "domain": "whatmydevice.com",
+        "source": "[SOURCE]"
+    }
+]

--- a/rules.txt
+++ b/rules.txt
@@ -1,0 +1,7 @@
+
+
+! [PULL REQUEST/ISSUE LINK]
+||whatmydevice.com^
+##a[href*="whatmydevice.com"], div:has(a[href*="whatmydevice.com"])
+google.*##.g:has(a[href*="whatmydevice.com"]), .tF2Cxc:has(a[href*="whatmydevice.com"]), .MjjYud:has(a[href*="whatmydevice.com"])
+duckduckgo.*##a[href*="whatmydevice.com"]:upward(article)

--- a/rules.txt
+++ b/rules.txt
@@ -1,6 +1,6 @@
 
 
-! [PULL REQUEST/ISSUE LINK]
+! https://github.com/progzone122/tech-dumbfucks-sites-list/pull/2
 ||whatmydevice.com^
 ##a[href*="whatmydevice.com"], div:has(a[href*="whatmydevice.com"])
 google.*##.g:has(a[href*="whatmydevice.com"]), .tF2Cxc:has(a[href*="whatmydevice.com"]), .MjjYud:has(a[href*="whatmydevice.com"])


### PR DESCRIPTION
Example: https://whatmydevice.com/unlock/motorola-moto-g23

Repeatedly lying about bootloader unlocking methods, offers a few universal guides that only work on some devices.
It's most likely a simple generation based on the model name.
Sucks!