### PR TITLE
add www.gsmprime.online

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -14,5 +14,9 @@
     {
         "domain": "onfix.cn",
         "source": "https://github.com/progzone122/tdsl/pull/5"
+    },
+    {
+        "domain": "www.gsmprime.online",
+        "source": "[SOURCE]"
     }
 ]

--- a/domains.json
+++ b/domains.json
@@ -17,6 +17,6 @@
     },
     {
         "domain": "www.gsmprime.online",
-        "source": "[SOURCE]"
+        "source": "https://github.com/progzone122/tdsl/pull/6"
     }
 ]

--- a/rules.txt
+++ b/rules.txt
@@ -24,7 +24,7 @@ duckduckgo.*##a[href*="rootingmaster.com"]:upward(article)
 google.*##.g:has(a[href*="onfix.cn"]), .tF2Cxc:has(a[href*="onfix.cn"]), .MjjYud:has(a[href*="onfix.cn"])
 duckduckgo.*##a[href*="onfix.cn"]:upward(article)
 
-! [SOURCE]
+! https://github.com/progzone122/tdsl/pull/6
 ||www.gsmprime.online^
 ##a[href*="www.gsmprime.online"], div:has(a[href*="www.gsmprime.online"])
 google.*##.g:has(a[href*="www.gsmprime.online"]), .tF2Cxc:has(a[href*="www.gsmprime.online"]), .MjjYud:has(a[href*="www.gsmprime.online"])

--- a/rules.txt
+++ b/rules.txt
@@ -23,3 +23,9 @@ duckduckgo.*##a[href*="rootingmaster.com"]:upward(article)
 ##a[href*="onfix.cn"], div:has(a[href*="onfix.cn"])
 google.*##.g:has(a[href*="onfix.cn"]), .tF2Cxc:has(a[href*="onfix.cn"]), .MjjYud:has(a[href*="onfix.cn"])
 duckduckgo.*##a[href*="onfix.cn"]:upward(article)
+
+! [SOURCE]
+||www.gsmprime.online^
+##a[href*="www.gsmprime.online"], div:has(a[href*="www.gsmprime.online"])
+google.*##.g:has(a[href*="www.gsmprime.online"]), .tF2Cxc:has(a[href*="www.gsmprime.online"]), .MjjYud:has(a[href*="www.gsmprime.online"])
+duckduckgo.*##a[href*="www.gsmprime.online"]:upward(article)


### PR DESCRIPTION
Example: https://www.gsmprime.online/aplicaciones
VirusTotal: https://www.virustotal.com/gui/file/7640282150d51c407ffdfe2fab35f2c60b93b0dc56ac93ad2459b16789aec61b

No contact information about the site owner, programs are downloaded from an anonymous source, half of the links are not clickable, malware.
Fuck them twice
