### PR TITLE
add unofficialtwrp.com

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -29,6 +29,6 @@
     },
     {
         "domain": "unofficialtwrp.com",
-        "source": "[SOURCE]"
+        "source": "https://github.com/progzone122/tdsl/pull/9"
     }
 ]

--- a/domains.json
+++ b/domains.json
@@ -26,5 +26,9 @@
     {
         "domain": "latestmobilefaq.com",
         "source": "https://github.com/progzone122/tdsl/pull/8"
+    },
+    {
+        "domain": "unofficialtwrp.com",
+        "source": "[SOURCE]"
     }
 ]

--- a/rules.txt
+++ b/rules.txt
@@ -42,7 +42,7 @@ duckduckgo.*##a[href*="mobilend.com.ua"]:upward(article)
 google.*##.g:has(a[href*="latestmobilefaq.com"]), .tF2Cxc:has(a[href*="latestmobilefaq.com"]), .MjjYud:has(a[href*="latestmobilefaq.com"])
 duckduckgo.*##a[href*="latestmobilefaq.com"]:upward(article)
 
-! [SOURCE]
+! https://github.com/progzone122/tdsl/pull/9
 ||unofficialtwrp.com^
 ##a[href*="unofficialtwrp.com"], div:has(a[href*="unofficialtwrp.com"])
 google.*##.g:has(a[href*="unofficialtwrp.com"]), .tF2Cxc:has(a[href*="unofficialtwrp.com"]), .MjjYud:has(a[href*="unofficialtwrp.com"])

--- a/rules.txt
+++ b/rules.txt
@@ -41,3 +41,9 @@ duckduckgo.*##a[href*="mobilend.com.ua"]:upward(article)
 ##a[href*="latestmobilefaq.com"], div:has(a[href*="latestmobilefaq.com"])
 google.*##.g:has(a[href*="latestmobilefaq.com"]), .tF2Cxc:has(a[href*="latestmobilefaq.com"]), .MjjYud:has(a[href*="latestmobilefaq.com"])
 duckduckgo.*##a[href*="latestmobilefaq.com"]:upward(article)
+
+! [SOURCE]
+||unofficialtwrp.com^
+##a[href*="unofficialtwrp.com"], div:has(a[href*="unofficialtwrp.com"])
+google.*##.g:has(a[href*="unofficialtwrp.com"]), .tF2Cxc:has(a[href*="unofficialtwrp.com"]), .MjjYud:has(a[href*="unofficialtwrp.com"])
+duckduckgo.*##a[href*="unofficialtwrp.com"]:upward(article)


### PR DESCRIPTION
Example: https://unofficialtwrp.com/unofficial-twrp-3-7-0-root-motorola-g23-penangf/

Non working firmware, completely non working guides, malware.
Did you know that you can install twrp without unlocking bootloader on 2023 release phone? And this site knows!