### PR TITLE
add rootingos.com

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -38,5 +38,9 @@
     {
         "domain": "www.getdroidtips.com",
         "source": "https://github.com/progzone122/tdsl/pull/11"
+    },
+    {
+        "domain": "rootingos.com",
+        "source": "[SOURCE]"
     }
 ]

--- a/domains.json
+++ b/domains.json
@@ -41,6 +41,6 @@
     },
     {
         "domain": "rootingos.com",
-        "source": "[SOURCE]"
+        "source": "https://github.com/progzone122/tdsl/pull/12"
     }
 ]

--- a/rules.txt
+++ b/rules.txt
@@ -59,3 +59,9 @@ duckduckgo.*##a[href*="proshivkis.ru"]:upward(article)
 ##a[href*="www.getdroidtips.com"], div:has(a[href*="www.getdroidtips.com"])
 google.*##.g:has(a[href*="www.getdroidtips.com"]), .tF2Cxc:has(a[href*="www.getdroidtips.com"]), .MjjYud:has(a[href*="www.getdroidtips.com"])
 duckduckgo.*##a[href*="www.getdroidtips.com"]:upward(article)
+
+! [SOURCE]
+||rootingos.com^
+##a[href*="rootingos.com"], div:has(a[href*="rootingos.com"])
+google.*##.g:has(a[href*="rootingos.com"]), .tF2Cxc:has(a[href*="rootingos.com"]), .MjjYud:has(a[href*="rootingos.com"])
+duckduckgo.*##a[href*="rootingos.com"]:upward(article)

--- a/rules.txt
+++ b/rules.txt
@@ -60,7 +60,7 @@ duckduckgo.*##a[href*="proshivkis.ru"]:upward(article)
 google.*##.g:has(a[href*="www.getdroidtips.com"]), .tF2Cxc:has(a[href*="www.getdroidtips.com"]), .MjjYud:has(a[href*="www.getdroidtips.com"])
 duckduckgo.*##a[href*="www.getdroidtips.com"]:upward(article)
 
-! [SOURCE]
+! https://github.com/progzone122/tdsl/pull/12
 ||rootingos.com^
 ##a[href*="rootingos.com"], div:has(a[href*="rootingos.com"])
 google.*##.g:has(a[href*="rootingos.com"]), .tF2Cxc:has(a[href*="rootingos.com"]), .MjjYud:has(a[href*="rootingos.com"])


### PR DESCRIPTION
Example:
- https://rootingos.com/root-moto-g24-5g/
- https://rootingos.com/root-asus-rog-phone-8/
- https://rootingos.com/root-iqoo-12-5g/

One non-working manual for all device models.
It seems that malware was previously available on the site
